### PR TITLE
Fix unexpected behavior when looking at a Bits Block from Bits and Chisels

### DIFF
--- a/src/main/java/mcp/mobius/waila/overlay/Tooltip.java
+++ b/src/main/java/mcp/mobius/waila/overlay/Tooltip.java
@@ -124,7 +124,7 @@ public class Tooltip {
     }
 
     public boolean hasItem() {
-        return showItem && Waila.CONFIG.get().getGeneral().shouldShowItem() && !RayTracing.INSTANCE.getIdentifierStack().isEmpty();
+        return showItem && Waila.CONFIG.get().getGeneral().shouldShowItem() && !RayTracing.INSTANCE.getIdentifierStack().isEmpty() && !RayTracing.INSTANCE.getIdentifierStack().toString().contains("bits_block");
     }
 
     public Rectangle getPosition() {


### PR DESCRIPTION
Title says it all. It used to hide your hand and crash unexpectedly.