### PR TITLE
Update pickerpriority when the picker is replaced

### DIFF
--- a/src/main/java/mcp/mobius/waila/registry/Registrar.java
+++ b/src/main/java/mcp/mobius/waila/registry/Registrar.java
@@ -225,6 +225,7 @@ public enum Registrar implements IRegistrar {
             assertLock();
             if (priority <= pickerPriority) {
                 this.picker = picker;
+                this.pickerPriority = priority;
             }
         }
     }


### PR DESCRIPTION
Update pickerpriority when the picker is replaced. This ensures that the objectpicker with the highest priority (lowest value) is actually used and not the objectpicker that gets registered at the latest point in time. This also needs to be updated for the dev/1.18 branch.