### PR TITLE
Make overrides merged config options instead of synced

### DIFF
--- a/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/WailaVanilla.java
+++ b/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/WailaVanilla.java
@@ -101,9 +101,9 @@ public class WailaVanilla implements IWailaPlugin {
         registrar.addComponent(MobTimerProvider.INSTANCE, BODY, AgeableMob.class);
         registrar.addEntityData(MobTimerProvider.INSTANCE, AgeableMob.class);
 
-        registrar.addSyncedConfig(Options.OVERRIDE_TRAPPED_CHEST, true, true);
-        registrar.addSyncedConfig(Options.OVERRIDE_POWDER_SNOW, true, true);
-        registrar.addSyncedConfig(Options.OVERRIDE_INFESTED, true, true);
+        registrar.addMergedConfig(Options.OVERRIDE_TRAPPED_CHEST, true, true);
+        registrar.addMergedConfig(Options.OVERRIDE_POWDER_SNOW, true, true);
+        registrar.addMergedConfig(Options.OVERRIDE_INFESTED, true, true);
         registrar.addOverride(InfestedBlockProvider.INSTANCE, InfestedBlock.class);
         registrar.addOverride(TrappedChestProvider.INSTANCE, TrappedChestBlock.class);
         registrar.addOverride(PowderSnowProvider.INSTANCE, PowderSnowBlock.class);

--- a/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/WailaVanilla.java
+++ b/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/WailaVanilla.java
@@ -103,7 +103,7 @@ public class WailaVanilla implements IWailaPlugin {
 
         registrar.addMergedConfig(Options.OVERRIDE_TRAPPED_CHEST, true);
         registrar.addMergedConfig(Options.OVERRIDE_POWDER_SNOW, true);
-        registrar.addMergedConfig(Options.OVERRIDE_INFESTED, true, true);
+        registrar.addMergedConfig(Options.OVERRIDE_INFESTED, true);
         registrar.addOverride(InfestedBlockProvider.INSTANCE, InfestedBlock.class);
         registrar.addOverride(TrappedChestProvider.INSTANCE, TrappedChestBlock.class);
         registrar.addOverride(PowderSnowProvider.INSTANCE, PowderSnowBlock.class);

--- a/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/WailaVanilla.java
+++ b/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/WailaVanilla.java
@@ -101,8 +101,8 @@ public class WailaVanilla implements IWailaPlugin {
         registrar.addComponent(MobTimerProvider.INSTANCE, BODY, AgeableMob.class);
         registrar.addEntityData(MobTimerProvider.INSTANCE, AgeableMob.class);
 
-        registrar.addMergedConfig(Options.OVERRIDE_TRAPPED_CHEST, true, true);
-        registrar.addMergedConfig(Options.OVERRIDE_POWDER_SNOW, true, true);
+        registrar.addMergedConfig(Options.OVERRIDE_TRAPPED_CHEST, true);
+        registrar.addMergedConfig(Options.OVERRIDE_POWDER_SNOW, true);
         registrar.addMergedConfig(Options.OVERRIDE_INFESTED, true, true);
         registrar.addOverride(InfestedBlockProvider.INSTANCE, InfestedBlock.class);
         registrar.addOverride(TrappedChestProvider.INSTANCE, TrappedChestBlock.class);


### PR DESCRIPTION
Currently, the override configurations (infested blocks, powder snow, trapped chest) are synced configurations, which make them unmodifiable in servers that do not have WTHIT installed. This is inconveniencing, since it prevents such blocks from being identified by WTHIT. I can see the motivation behind this change, which is to obfuscate the block types of blocks that appear identical. However, this behavior is not always desired, such as when building in creative servers. In addition, having WTHIT hide the block types do not accomplish the goal of obfuscating the blocks, since the F3 debug menu will still show the true block type, along with resource packs too. Additionally, powder snow has a different texture than snow, so it can be distinguished by just looking at it. This pull request resolves the problem by changing the configuration settings to be merged, allowing the options to be changed without having a WTHIT server and allowing the options to be changed in the client. This won't grant any advantages in block distinguishing, since the F3 menu can still show the true types of blocks, and WTHIT's overrides are inconveniencing at best.