### PR TITLE
feat: add ability to show container contents with item names

### DIFF
--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
@@ -18,11 +18,12 @@ public class NamedItemComponent implements ITooltipComponent {
 
     public static final NamedItemComponent EMPTY = new NamedItemComponent(ItemStack.EMPTY);
 
-    private static final Font FONT = Minecraft.getInstance().font;
-    public static final int HEIGHT = FONT.lineHeight;
-
     public NamedItemComponent(ItemStack stack) {
         this.stack = stack;
+
+        var count = stack.getCount();
+        var name = stack.getHoverName().getString();
+        this.label = count > 1 ? WailaHelper.suffix(count) + " " + name : name;
     }
 
     public NamedItemComponent(ItemLike item) {
@@ -30,21 +31,16 @@ public class NamedItemComponent implements ITooltipComponent {
     }
 
     public final ItemStack stack;
-
-    private String getText() {
-        var count = stack.getCount();
-        var name = stack.getHoverName().getString();
-        return count > 1 ? WailaHelper.suffix(count) + " " + name : name;
-    }
+    public final String label;
 
     @Override
     public int getWidth() {
-        return FONT.width(getText()) + 10;
+        return getFont().width(label) + 10;
     }
 
     @Override
     public int getHeight() {
-        return HEIGHT;
+        return getFont().lineHeight;
     }
 
     @Override
@@ -56,7 +52,11 @@ public class NamedItemComponent implements ITooltipComponent {
         ctx.renderItem(stack, 0, 0);
         pose.popPose();
 
-        ctx.drawString(FONT, getText(), x + 10, y, IApiService.INSTANCE.getFontColor());
+        ctx.drawString(getFont(), label, x + 10, y, IApiService.INSTANCE.getFontColor());
+    }
+
+    private Font getFont() {
+        return Minecraft.getInstance().font;
     }
 
 }

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
@@ -30,7 +30,7 @@ public class NamedItemComponent implements ITooltipComponent {
 
     public final ItemStack stack;
 
-    protected String getText() {
+    private String getText() {
         var count = stack.getCount();
         var name = stack.getHoverName().getString();
         return count > 1 ? count + "x " + name : name;

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
@@ -1,0 +1,61 @@
+package mcp.mobius.waila.api.component;
+
+import mcp.mobius.waila.api.ITooltipComponent;
+import mcp.mobius.waila.api.__internal__.ApiSide;
+import mcp.mobius.waila.api.__internal__.IApiService;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+
+/**
+ * Component that renders an {@link ItemStack} with its name.
+ */
+@ApiSide.ClientOnly
+public class NamedItemComponent implements ITooltipComponent {
+
+    public static final NamedItemComponent EMPTY = new NamedItemComponent(ItemStack.EMPTY);
+
+    private static final Font FONT = Minecraft.getInstance().font;
+    public static final int HEIGHT = FONT.lineHeight;
+
+    public NamedItemComponent(ItemStack stack) {
+        this.stack = stack;
+    }
+
+    public NamedItemComponent(ItemLike item) {
+        this(new ItemStack(item));
+    }
+
+    public final ItemStack stack;
+
+    protected String getText() {
+        var count = stack.getCount();
+        var name = stack.getHoverName().getString();
+        return count + "x " + name;
+    }
+
+    @Override
+    public int getWidth() {
+        return FONT.width(getText()) + 10;
+    }
+
+    @Override
+    public int getHeight() {
+        return HEIGHT;
+    }
+
+    @Override
+    public void render(GuiGraphics ctx, int x, int y, float delta) {
+        var pose = ctx.pose();
+        pose.pushPose();
+        pose.translate(x, y, 0);
+        pose.scale(0.5f, 0.5f, 0.5f);
+        ctx.renderItem(stack, 0, 0);
+        pose.popPose();
+
+        ctx.drawString(FONT, getText(), x + 10, y, IApiService.INSTANCE.getFontColor());
+    }
+
+}

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
@@ -33,7 +33,7 @@ public class NamedItemComponent implements ITooltipComponent {
     protected String getText() {
         var count = stack.getCount();
         var name = stack.getHoverName().getString();
-        return count + "x " + name;
+        return count > 1 ? count + "x " + name : name;
     }
 
     @Override

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemComponent.java
@@ -1,6 +1,7 @@
 package mcp.mobius.waila.api.component;
 
 import mcp.mobius.waila.api.ITooltipComponent;
+import mcp.mobius.waila.api.WailaHelper;
 import mcp.mobius.waila.api.__internal__.ApiSide;
 import mcp.mobius.waila.api.__internal__.IApiService;
 import net.minecraft.client.Minecraft;
@@ -33,7 +34,7 @@ public class NamedItemComponent implements ITooltipComponent {
     private String getText() {
         var count = stack.getCount();
         var name = stack.getHoverName().getString();
-        return count > 1 ? count + "x " + name : name;
+        return count > 1 ? WailaHelper.suffix(count) + " " + name : name;
     }
 
     @Override

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemListComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemListComponent.java
@@ -6,6 +6,7 @@ import java.util.List;
 import mcp.mobius.waila.api.ITooltipComponent;
 import mcp.mobius.waila.api.__internal__.ApiSide;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
 /**
@@ -14,7 +15,7 @@ import net.minecraft.world.item.ItemStack;
 @ApiSide.ClientOnly
 public class NamedItemListComponent implements ITooltipComponent {
 
-    private static final More MORE = new More();
+    private static final NamedItemComponent MORE = new NamedItemComponent(ItemStack.EMPTY.setHoverName(Component.literal("...")));;
 
     public NamedItemListComponent(List<ItemStack> items, int maxHeight) {
         this.items = items;
@@ -59,18 +60,6 @@ public class NamedItemListComponent implements ITooltipComponent {
             var component = getComponents().get(i);
             var iy = y + (i * NamedItemComponent.HEIGHT);
             component.render(ctx, x, iy, delta);
-        }
-    }
-
-    private static class More extends NamedItemComponent {
-
-        public More() {
-            super(ItemStack.EMPTY);
-        }
-
-        @Override
-        protected String getText() {
-            return "...";
         }
     }
 

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemListComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemListComponent.java
@@ -1,0 +1,77 @@
+package mcp.mobius.waila.api.component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mcp.mobius.waila.api.ITooltipComponent;
+import mcp.mobius.waila.api.__internal__.ApiSide;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Component that renders items with their names.
+ */
+@ApiSide.ClientOnly
+public class NamedItemListComponent implements ITooltipComponent {
+
+    private static final More MORE = new More();
+
+    public NamedItemListComponent(List<ItemStack> items, int maxHeight) {
+        this.items = items;
+        this.maxHeight = maxHeight;
+    }
+
+    private final List<ItemStack> items;
+    private final int maxHeight;
+
+    private List<NamedItemComponent> getComponents() {
+        List<NamedItemComponent> components = new ArrayList<>();
+
+        for (var i = 0; i < items.size(); i++) {
+            if (i >= maxHeight) break;
+            components.add(new NamedItemComponent(items.get(i)));
+        }
+
+        if (items.size() > maxHeight) {
+            components.add(MORE);
+        }
+
+        return components;
+    }
+
+    @Override
+    public int getWidth() {
+        var maxWidth = 0;
+        for (var component : getComponents()) {
+            maxWidth = Math.max(maxWidth, component.getWidth());
+        }
+        return maxWidth;
+    }
+
+    @Override
+    public int getHeight() {
+        return getComponents().size() * NamedItemComponent.HEIGHT;
+    }
+
+    @Override
+    public void render(GuiGraphics ctx, int x, int y, float delta) {
+        for (var i = 0; i < getComponents().size(); i++) {
+            var component = getComponents().get(i);
+            var iy = y + (i * NamedItemComponent.HEIGHT);
+            component.render(ctx, x, iy, delta);
+        }
+    }
+
+    private static class More extends NamedItemComponent {
+
+        public More() {
+            super(ItemStack.EMPTY);
+        }
+
+        @Override
+        protected String getText() {
+            return "...";
+        }
+    }
+
+}

--- a/src/api/java/mcp/mobius/waila/api/component/NamedItemListComponent.java
+++ b/src/api/java/mcp/mobius/waila/api/component/NamedItemListComponent.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import mcp.mobius.waila.api.ITooltipComponent;
 import mcp.mobius.waila.api.__internal__.ApiSide;
+import mcp.mobius.waila.api.__internal__.IApiService;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
 /**
@@ -15,52 +17,61 @@ import net.minecraft.world.item.ItemStack;
 @ApiSide.ClientOnly
 public class NamedItemListComponent implements ITooltipComponent {
 
-    private static final NamedItemComponent MORE = new NamedItemComponent(ItemStack.EMPTY.setHoverName(Component.literal("...")));;
+    private static final String MORE = "...";
 
     public NamedItemListComponent(List<ItemStack> items, int maxHeight) {
-        this.items = items;
-        this.maxHeight = maxHeight;
-    }
-
-    private final List<ItemStack> items;
-    private final int maxHeight;
-
-    private List<NamedItemComponent> getComponents() {
-        List<NamedItemComponent> components = new ArrayList<>();
-
+        this.components = new ArrayList<>(Math.min(items.size(), maxHeight));
         for (var i = 0; i < items.size(); i++) {
             if (i >= maxHeight) break;
-            components.add(new NamedItemComponent(items.get(i)));
+            this.components.add(new NamedItemComponent(items.get(i)));
         }
 
-        if (items.size() > maxHeight) {
-            components.add(MORE);
-        }
-
-        return components;
+        this.hasOverflow = items.size() > maxHeight;
     }
+
+    private final List<NamedItemComponent> components;
+    private final boolean hasOverflow;
 
     @Override
     public int getWidth() {
         var maxWidth = 0;
-        for (var component : getComponents()) {
+        for (var component : components) {
             maxWidth = Math.max(maxWidth, component.getWidth());
+        }
+        if (hasOverflow) {
+            maxWidth = Math.max(maxWidth, getFont().width(MORE) + 10);
         }
         return maxWidth;
     }
 
     @Override
     public int getHeight() {
-        return getComponents().size() * NamedItemComponent.HEIGHT;
+        var height = 0;
+        for (var component : components) {
+            height += component.getHeight();
+        }
+        if (hasOverflow) {
+            height += getFont().lineHeight;
+        }
+        return height;
     }
 
     @Override
     public void render(GuiGraphics ctx, int x, int y, float delta) {
-        for (var i = 0; i < getComponents().size(); i++) {
-            var component = getComponents().get(i);
-            var iy = y + (i * NamedItemComponent.HEIGHT);
+        var iy = y;
+
+        for (var component : components) {
             component.render(ctx, x, iy, delta);
+            iy += component.getHeight();
         }
+
+        if (hasOverflow) {
+            ctx.drawString(getFont(), MORE, x + 10, iy, IApiService.INSTANCE.getFontColor());
+        }
+    }
+
+    private Font getFont() {
+        return Minecraft.getInstance().font;
     }
 
 }

--- a/src/api/java/mcp/mobius/waila/api/data/ItemData.java
+++ b/src/api/java/mcp/mobius/waila/api/data/ItemData.java
@@ -22,6 +22,7 @@ public abstract class ItemData implements IData {
     public static final ResourceLocation ID = BuiltinDataUtil.rl("item");
     public static final ResourceLocation CONFIG_SYNC_NBT = BuiltinDataUtil.rl("item.nbt");
     public static final ResourceLocation CONFIG_MAX_HEIGHT = BuiltinDataUtil.rl("item.max_height");
+    public static final ResourceLocation CONFIG_SHOW_NAMES = BuiltinDataUtil.rl("item.show_names");
     public static final ResourceLocation CONFIG_SORT_BY_COUNT = BuiltinDataUtil.rl("item.sort_by_count");
 
     /**

--- a/src/pluginExtra/java/mcp/mobius/waila/plugin/extra/provider/ItemProvider.java
+++ b/src/pluginExtra/java/mcp/mobius/waila/plugin/extra/provider/ItemProvider.java
@@ -11,6 +11,8 @@ import mcp.mobius.waila.api.IDataReader;
 import mcp.mobius.waila.api.IPluginConfig;
 import mcp.mobius.waila.api.IRegistrar;
 import mcp.mobius.waila.api.ITooltip;
+import mcp.mobius.waila.api.ITooltipComponent;
+import mcp.mobius.waila.api.component.ItemListComponent;
 import mcp.mobius.waila.api.component.NamedItemListComponent;
 import mcp.mobius.waila.api.data.ItemData;
 import mcp.mobius.waila.api.data.ProgressData;
@@ -28,7 +30,7 @@ public class ItemProvider extends DataProvider<ItemData, ItemDataImpl> {
     private static final CompoundTag EMPTY = new CompoundTag();
 
     private @Nullable ItemData lastData = null;
-    private @Nullable NamedItemListComponent lastItemsComponent = null;
+    private @Nullable ITooltipComponent lastItemsComponent = null;
 
     protected ItemProvider() {
         super(ItemData.ID, ItemData.class, ItemDataImpl.class, ItemDataImpl::new);
@@ -38,6 +40,7 @@ public class ItemProvider extends DataProvider<ItemData, ItemDataImpl> {
     protected void registerAdditions(IRegistrar registrar, int priority) {
         registrar.addSyncedConfig(ItemData.CONFIG_SYNC_NBT, true, false);
         registrar.addConfig(ItemData.CONFIG_MAX_HEIGHT, 3);
+        registrar.addConfig(ItemData.CONFIG_SHOW_NAMES, false);
         registrar.addConfig(ItemData.CONFIG_SORT_BY_COUNT, true);
     }
 
@@ -91,7 +94,12 @@ public class ItemProvider extends DataProvider<ItemData, ItemDataImpl> {
             stream = stream.sorted(Comparator.comparingInt(ItemStack::getCount).reversed());
         }
 
-        tooltip.setLine(ItemData.ID, lastItemsComponent = new NamedItemListComponent(stream.toList(), config.getInt(ItemData.CONFIG_MAX_HEIGHT)));
+        if (config.getBoolean(ItemData.CONFIG_SHOW_NAMES)) {
+            lastItemsComponent = new NamedItemListComponent(stream.toList(), config.getInt(ItemData.CONFIG_MAX_HEIGHT));
+        } else {
+            lastItemsComponent = new ItemListComponent(stream.toList(), config.getInt(ItemData.CONFIG_MAX_HEIGHT));
+        }
+        tooltip.setLine(ItemData.ID, lastItemsComponent);
     }
 
     private record ItemWithNbt(Item item, CompoundTag tag) {

--- a/src/pluginExtra/java/mcp/mobius/waila/plugin/extra/provider/ItemProvider.java
+++ b/src/pluginExtra/java/mcp/mobius/waila/plugin/extra/provider/ItemProvider.java
@@ -11,7 +11,7 @@ import mcp.mobius.waila.api.IDataReader;
 import mcp.mobius.waila.api.IPluginConfig;
 import mcp.mobius.waila.api.IRegistrar;
 import mcp.mobius.waila.api.ITooltip;
-import mcp.mobius.waila.api.component.ItemListComponent;
+import mcp.mobius.waila.api.component.NamedItemListComponent;
 import mcp.mobius.waila.api.data.ItemData;
 import mcp.mobius.waila.api.data.ProgressData;
 import mcp.mobius.waila.plugin.extra.data.ItemDataImpl;
@@ -28,7 +28,7 @@ public class ItemProvider extends DataProvider<ItemData, ItemDataImpl> {
     private static final CompoundTag EMPTY = new CompoundTag();
 
     private @Nullable ItemData lastData = null;
-    private @Nullable ItemListComponent lastItemsComponent = null;
+    private @Nullable NamedItemListComponent lastItemsComponent = null;
 
     protected ItemProvider() {
         super(ItemData.ID, ItemData.class, ItemDataImpl.class, ItemDataImpl::new);
@@ -91,7 +91,7 @@ public class ItemProvider extends DataProvider<ItemData, ItemDataImpl> {
             stream = stream.sorted(Comparator.comparingInt(ItemStack::getCount).reversed());
         }
 
-        tooltip.setLine(ItemData.ID, lastItemsComponent = new ItemListComponent(stream.toList(), config.getInt(ItemData.CONFIG_MAX_HEIGHT)));
+        tooltip.setLine(ItemData.ID, lastItemsComponent = new NamedItemListComponent(stream.toList(), config.getInt(ItemData.CONFIG_MAX_HEIGHT)));
     }
 
     private record ItemWithNbt(Item item, CompoundTag tag) {

--- a/src/resources/resources/assets/waila/lang/en_us.json
+++ b/src/resources/resources/assets/waila/lang/en_us.json
@@ -352,6 +352,7 @@
   "config.waila.plugin_wailax.item.enabled_entity"             : "Show Entity Item Contents",
   "config.waila.plugin_wailax.item.nbt"                        : "Sync NBT Data",
   "config.waila.plugin_wailax.item.max_height"                 : "Max Height",
+  "config.waila.plugin_wailax.item.show_names"                 : "Show Item Names",
   "config.waila.plugin_wailax.item.sort_by_count"              : "Sort by Count",
   "config.waila.plugin_wailax.item.blacklist"                  : "Item Contents Blacklist",
   "config.waila.plugin_wailax.fluid"                           : "Fluid",


### PR DESCRIPTION
## Proposed changes

- Add `NamedItemComponent` and `NamedItemListComponent` to API
- Add `Show Item Names` option to config, disabled by default

**Tested on Fabric 0.15.11, Minecraft 1.20.1**

## Description

This change adds two new components to the API and an option to enable them for the `ItemProvider` in wailax plugin.

The `NamedItemComponent` is used to display a single item, similar to the `ItemComponent`. I found it useful for Create's Placard (alternative to ItemFrame) and for Copycat material:
![2024-06-01_21 42 56](https://github.com/badasintended/wthit/assets/9871630/0929da0a-1264-4422-87c9-15c7dd0c4b2e)

The `NamedItemListComponent` is used to display a list of items, like the contents of a chest or a drawer. I like to use it with Modern Industrialization, where you have a lot of items with similar icons, so it's much easier to distinguish them by their names.

Some screenshots:
![2024-06-01_21 16 08](https://github.com/badasintended/wthit/assets/9871630/c99356b7-0696-483d-abf0-2c6712be087e)
![2024-06-01_21 16 53](https://github.com/badasintended/wthit/assets/9871630/11d281e5-6d4a-4c95-998f-05bb1ad629f6)

If the number of item types is greater than the `maxHeight` value, "..." is will be displayed to indicate that there are more items in the container. Players may want to adjust this setting, as the default value of 3 will only show 3 items. With `maxHeight=10` it looks like this:
![2024-06-01_21 16 34](https://github.com/badasintended/wthit/assets/9871630/b0e04c4c-a6fa-493b-ad23-6261d4bae392)
