### PR TITLE
Fix beehive occupant tooltip in 1.21.10

### DIFF
--- a/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/provider/data/BeehiveDataProvider.java
+++ b/src/pluginVanilla/java/mcp/mobius/waila/plugin/vanilla/provider/data/BeehiveDataProvider.java
@@ -40,19 +40,13 @@ public enum BeehiveDataProvider implements IDataProvider<BeehiveBlockEntity> {
                 var occupants = new ArrayList<OccupantsData.Occupant>(stored.size());
 
                 for (var beeData : stored) {
-                    var beeNbt = beeData.wthit_occupant().entityData().getUnsafe();
-                    var entityTypeId = beeNbt.getString("id").orElse(null);
-                    if (entityTypeId == null) continue;
-
-                    var entityType = EntityType.byString(entityTypeId).orElse(null);
-                    if (entityType == null) continue;
-
+                    var entityType = beeData.wthit_occupant().entityData().type();
+                    var beeNbt = beeData.wthit_occupant().entityData().copyTagWithoutId();
                     var customName = beeNbt.getString("CustomName").orElse(null);
-
                     occupants.add(new OccupantsData.Occupant(entityType, customName));
                 }
 
-                if (!occupants.isEmpty()) data.addImmediate(new OccupantsData(occupants));
+                data.addImmediate(new OccupantsData(occupants));
             }
         }
     }


### PR DESCRIPTION
I noticed that beehive occupants were no longer listed in the tooltip in 1.21.10. Apparently the "id" tag is now removed from the bee NBT, and you need to get the type a different way.