### PR TITLE
add papermc support

### DIFF
--- a/lol/bai/badpackets/impl/Constants.java
+++ b/lol/bai/badpackets/impl/Constants.java
@@ -1,0 +1,22 @@
+package lol.bai.badpackets.impl;
+
+import net.minecraft.resources.Identifier;
+
+public class Constants {
+
+    public static final String MOD_ID = "badpackets";
+
+    public static final Identifier CHANNEL_SYNC = id("channel_sync");
+    public static final Identifier MC_REGISTER_CHANNEL = Identifier.parse("minecraft:register");
+    public static final Identifier MC_UNREGISTER_CHANNEL = Identifier.parse("minecraft:unregister");
+
+    public static final int PING_PONG = 0xBAD4C7_01;
+
+    public static final byte CHANNEL_SYNC_SINGLE = 0;
+    public static final byte CHANNEL_SYNC_INITIAL = 1;
+
+    public static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath(MOD_ID, path);
+    }
+
+}

--- a/lol/bai/badpackets/impl/handler/AbstractPacketHandler.java
+++ b/lol/bai/badpackets/impl/handler/AbstractPacketHandler.java
@@ -1,0 +1,172 @@
+package lol.bai.badpackets.impl.handler;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import lol.bai.badpackets.api.PacketReceiver;
+import lol.bai.badpackets.api.PacketSender;
+import lol.bai.badpackets.impl.Constants;
+import lol.bai.badpackets.impl.payload.UntypedPayload;
+import lol.bai.badpackets.impl.platform.PlatformProxy;
+import lol.bai.badpackets.impl.registry.ChannelRegistry;
+import net.minecraft.network.Connection;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.thread.BlockableEventLoop;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public abstract class AbstractPacketHandler<C, B extends FriendlyByteBuf> implements PacketSender {
+
+    protected final ChannelRegistry<B, C> registry;
+    protected final Logger logger;
+
+    private final Function<CustomPacketPayload, Packet<?>> packetFactory;
+    private final Set<Identifier> sendableChannels = Collections.synchronizedSet(new HashSet<>());
+
+    private final BlockableEventLoop<?> eventLoop;
+    private final Connection connection;
+
+    private boolean initialized = false;
+
+    protected AbstractPacketHandler(String desc, ChannelRegistry<B, C> registry, Function<CustomPacketPayload, Packet<?>> packetFactory, BlockableEventLoop<?> eventLoop, Connection connection) {
+        this.logger = LogManager.getLogger(desc);
+        this.registry = registry;
+        this.packetFactory = packetFactory;
+        this.eventLoop = eventLoop;
+        this.connection = connection;
+
+        registry.addHandler(this);
+    }
+
+    private void receiveChannelSyncPacket(FriendlyByteBuf buf) {
+        switch (buf.readByte()) {
+            case Constants.CHANNEL_SYNC_SINGLE -> sendableChannels.add(buf.readIdentifier());
+            case Constants.CHANNEL_SYNC_INITIAL -> {
+                int groupSize = buf.readVarInt();
+                for (int i = 0; i < groupSize; i++) {
+                    String namespace = buf.readUtf();
+
+                    int pathSize = buf.readVarInt();
+                    for (int j = 0; j < pathSize; j++) {
+                        String path = buf.readUtf();
+                        sendableChannels.add(Identifier.fromNamespaceAndPath(namespace, path));
+                    }
+                }
+
+                eventLoop.execute(this::onInitialChannelSyncPacketReceived);
+            }
+        }
+    }
+
+    public boolean receive(CustomPacketPayload payload) {
+        Identifier id = payload.type().id();
+
+        if (id.equals(Constants.CHANNEL_SYNC)) {
+            UntypedPayload untyped = (UntypedPayload) payload;
+            receiveChannelSyncPacket(untyped.buffer());
+            return true;
+        }
+
+        if (registry.has(id)) {
+            try {
+                PacketReceiver<C, CustomPacketPayload> receiver = registry.get(id);
+
+                if (payload instanceof UntypedPayload || eventLoop.isSameThread()) {
+                    receiveUnsafe(receiver, payload);
+                } else eventLoop.execute(() -> {
+                    if (connection.isConnected()) receiveUnsafe(receiver, payload);
+                });
+            } catch (Throwable t) {
+                logger.error("Error when receiving packet {}", id, t);
+                throw t;
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    protected abstract void onInitialChannelSyncPacketReceived();
+
+    protected abstract void receiveUnsafe(PacketReceiver<C, CustomPacketPayload> receiver, CustomPacketPayload payload);
+
+    public void sendInitialChannelSyncPacket() {
+        if (!initialized) {
+            initialized = true;
+            sendVanillaChannelRegisterPacket(Set.of(Constants.CHANNEL_SYNC));
+
+            Set<Identifier> channels = registry.getChannels();
+            FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+            buf.writeByte(Constants.CHANNEL_SYNC_INITIAL);
+
+            Map<String, List<Identifier>> group = channels.stream().collect(Collectors.groupingBy(Identifier::getNamespace));
+            buf.writeVarInt(group.size());
+
+            for (Map.Entry<String, List<Identifier>> entry : group.entrySet()) {
+                buf.writeUtf(entry.getKey());
+                buf.writeVarInt(entry.getValue().size());
+
+                for (Identifier value : entry.getValue()) {
+                    buf.writeUtf(value.getPath());
+                }
+            }
+
+            send(Constants.CHANNEL_SYNC, buf);
+            sendVanillaChannelRegisterPacket(channels);
+        }
+    }
+
+    public void onRegister(Identifier id) {
+        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+        buf.writeByte(Constants.CHANNEL_SYNC_SINGLE);
+        buf.writeIdentifier(id);
+        send(Constants.CHANNEL_SYNC, buf);
+        sendVanillaChannelRegisterPacket(Set.of(id));
+    }
+
+    public void remove() {
+        registry.removeHandler(this);
+    }
+
+    private void sendVanillaChannelRegisterPacket(Set<Identifier> channels) {
+        if (PlatformProxy.INSTANCE.canSendVanillaRegisterPackets() && !channels.isEmpty()) {
+            connection.send(createVanillaRegisterPacket(channels, buf -> {
+                boolean first = true;
+                for (Identifier channel : channels) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        buf.writeByte(0);
+                    }
+                    buf.writeBytes(channel.toString().getBytes(StandardCharsets.US_ASCII));
+                }
+            }));
+        }
+    }
+
+    protected abstract Packet<?> createVanillaRegisterPacket(Set<Identifier> channels, Consumer<B> buf);
+
+    @Override
+    public void send(CustomPacketPayload payload, @Nullable ChannelFutureListener callback) {
+        connection.send(packetFactory.apply(payload), callback);
+    }
+
+    @Override
+    public boolean canSend(Identifier id) {
+        return sendableChannels.contains(id);
+    }
+
+}

--- a/platform/paper/build.gradle.kts
+++ b/platform/paper/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+    id("de.undercouch.download")
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.18"
+}
+
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
+
+val badpacketsApi: Configuration by configurations.creating {
+    isTransitive = false
+}
+
+dependencies {
+    paperweight.paperDevBundle("${rootProp["minecraft"]}-R0.1-SNAPSHOT")
+    compileOnly("lol.bai:badpackets:mojmap-${rootProp["badpackets"]}")
+    badpacketsApi("lol.bai:badpackets:mojmap-${rootProp["badpackets"]}")
+}
+
+sourceSets {
+    val main by getting
+    val rootSourceSets = rootProject.extensions.getByType<SourceSetContainer>()
+
+    main.apply {
+        resources.srcDir(rootProject.file("src/resources/resources"))
+        rootSourceSets.forEach {
+            compileClasspath += it.output
+            runtimeClasspath += it.output
+        }
+    }
+}
+
+tasks {
+    processResources {
+        inputs.property("version", project.version)
+
+        filesMatching("paper-plugin.yml") {
+            expand("version" to project.version)
+        }
+    }
+
+    val jar by getting(Jar::class) {
+        rootProject.extensions.getByType<SourceSetContainer>()
+            .filter { it.name != "mixin" && it.name != "buildConst" && it.name != "test" }
+            .forEach { from(it.output) }
+
+        // Bundle BadPackets API classes — needed at runtime because Paper doesn't have BadPackets as a mod,
+        // but root project classes (DataWriter, Packets, etc.) reference BadPackets types in method signatures.
+        from(badpacketsApi.map { if (it.isDirectory) it else zipTree(it) }) {
+            include("lol/bai/badpackets/api/**")
+        }
+    }
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/AbstractFurnaceBlockEntityAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/AbstractFurnaceBlockEntityAccess.java
@@ -1,0 +1,12 @@
+package mcp.mobius.waila.mixin;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface AbstractFurnaceBlockEntityAccess {
+
+    int wthit_cookingTimer();
+
+    int wthit_cookingTotalTime();
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/BaseContainerBlockEntityAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/BaseContainerBlockEntityAccess.java
@@ -1,0 +1,16 @@
+package mcp.mobius.waila.mixin;
+
+import net.minecraft.world.LockCode;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor
+ * generated at runtime. On Paper, the cast to this interface will fail
+ * with ClassCastException (caught by WTHIT's error handler).
+ */
+public interface BaseContainerBlockEntityAccess {
+
+    LockCode wthit_lockKey();
+
+    void wthit_lockKey(LockCode lockKey);
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/BeaconBlockEntityAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/BeaconBlockEntityAccess.java
@@ -1,0 +1,20 @@
+package mcp.mobius.waila.mixin;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.effect.MobEffect;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface BeaconBlockEntityAccess {
+
+    @Nullable
+    Holder<MobEffect> wthit_primaryPower();
+
+    @Nullable
+    Holder<MobEffect> wthit_secondaryPower();
+
+    int wthit_levels();
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/BeehiveBlockEntity$BeeDataAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/BeehiveBlockEntity$BeeDataAccess.java
@@ -1,0 +1,12 @@
+package mcp.mobius.waila.mixin;
+
+import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface BeehiveBlockEntity$BeeDataAccess {
+
+    BeehiveBlockEntity.Occupant wthit_occupant();
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/BeehiveBlockEntityAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/BeehiveBlockEntityAccess.java
@@ -1,0 +1,12 @@
+package mcp.mobius.waila.mixin;
+
+import java.util.List;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface BeehiveBlockEntityAccess {
+
+    List<BeehiveBlockEntity$BeeDataAccess> wthit_stored();
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/EntityAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/EntityAccess.java
@@ -1,0 +1,12 @@
+package mcp.mobius.waila.mixin;
+
+import net.minecraft.network.chat.Component;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface EntityAccess {
+
+    Component wthit_getTypeName();
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/LecternBlockEntityAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/LecternBlockEntityAccess.java
@@ -1,0 +1,10 @@
+package mcp.mobius.waila.mixin;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface LecternBlockEntityAccess {
+
+    int wthit_pageCount();
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/mixin/NoteBlockAccess.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/mixin/NoteBlockAccess.java
@@ -1,0 +1,15 @@
+package mcp.mobius.waila.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Stub interface for Paper. On Fabric/Forge, this is a mixin accessor.
+ */
+public interface NoteBlockAccess {
+
+    @Nullable Identifier wthit_getCustomSoundId(Level world, BlockPos pos);
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/BlacklistConfig.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/BlacklistConfig.java
@@ -1,0 +1,17 @@
+package mcp.mobius.waila.paper;
+
+import java.util.LinkedHashSet;
+
+import org.bukkit.NamespacedKey;
+
+@SuppressWarnings("unused")
+public class BlacklistConfig {
+
+    public final LinkedHashSet<NamespacedKey> blocks = new LinkedHashSet<>();
+    public final LinkedHashSet<NamespacedKey> blockEntityTypes = new LinkedHashSet<>();
+    public final LinkedHashSet<NamespacedKey> entityTypes = new LinkedHashSet<>();
+
+    public final int configVersion = 0;
+    public final int[] pluginHash = {0, 0, 0};
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/NamespacedKeySerializer.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/NamespacedKeySerializer.java
@@ -1,0 +1,26 @@
+package mcp.mobius.waila.paper;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import org.bukkit.NamespacedKey;
+
+public class NamespacedKeySerializer implements JsonSerializer<NamespacedKey>, JsonDeserializer<NamespacedKey> {
+
+    @Override
+    public NamespacedKey deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return NamespacedKey.fromString(json.getAsString());
+    }
+
+    @Override
+    public JsonElement serialize(NamespacedKey src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(src.toString());
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperApiService.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperApiService.java
@@ -1,0 +1,6 @@
+package mcp.mobius.waila.paper;
+
+import mcp.mobius.waila.service.ApiService;
+
+public class PaperApiService extends ApiService {
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperCommonService.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperCommonService.java
@@ -1,0 +1,59 @@
+package mcp.mobius.waila.paper;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import mcp.mobius.waila.plugin.PluginSide;
+import mcp.mobius.waila.service.ICommonService;
+import mcp.mobius.waila.util.ModInfo;
+import org.bukkit.Bukkit;
+
+public class PaperCommonService implements ICommonService {
+
+    @Override
+    public String getPlatformName() {
+        return "Paper";
+    }
+
+    @Override
+    public Path getGameDir() {
+        return Path.of(".");
+    }
+
+    @Override
+    public Path getConfigDir() {
+        return Path.of("plugins/wthit");
+    }
+
+    @Override
+    public Optional<ModInfo> createModInfo(String namespace) {
+        if (namespace.equals("wthit") || namespace.equals("waila")) {
+            var plugin = Bukkit.getPluginManager().getPlugin("wthit");
+            if (plugin != null) {
+                return Optional.of(new ModInfo(true, "wthit", plugin.getName(), plugin.getDescription().getVersion()));
+            }
+        }
+
+        if (namespace.equals("minecraft")) {
+            return Optional.of(new ModInfo(true, "minecraft", "Minecraft", Bukkit.getMinecraftVersion()));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isDev() {
+        return false;
+    }
+
+    @Override
+    public PluginSide getSide() {
+        return PluginSide.DEDICATED_SERVER;
+    }
+
+    @Override
+    public String getIssueUrl() {
+        return "https://github.com/badasintended/wthit/issues";
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperDataHandler.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperDataHandler.java
@@ -1,0 +1,143 @@
+package mcp.mobius.waila.paper;
+
+import java.util.logging.Level;
+
+import io.netty.buffer.Unpooled;
+import mcp.mobius.waila.access.DataReader;
+import mcp.mobius.waila.access.DataWriter;
+import mcp.mobius.waila.access.ServerAccessor;
+import mcp.mobius.waila.api.IDataProvider;
+import mcp.mobius.waila.api.IServerAccessor;
+import mcp.mobius.waila.config.PluginConfig;
+import mcp.mobius.waila.registry.Registrar;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Handles incoming block and entity data request messages from the WTHIT client mod.
+ * Deserializes request packets using NMS, runs the full IDataProvider pipeline to gather
+ * data from all registered providers, and sends responses back via PaperPacketSender.
+ * <p>
+ * Important: These handlers must run on the main server thread because
+ * {@code DataWriter.SERVER} and {@code DataReader.SERVER} are stateful singletons
+ * that are not thread-safe. Bukkit's {@code PluginMessageListener} dispatches on
+ * the main thread, which matches the threading model of the vanilla WTHIT mod.
+ */
+public class PaperDataHandler {
+
+    private final Plugin plugin;
+
+    public PaperDataHandler(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Handles a block data request from the client.
+     * <p>
+     * Deserializes a {@link BlockHitResult} from the raw bytes, looks up the block entity
+     * at the target position, runs all registered data providers, and sends the response
+     * via the full DataWriter pipeline.
+     */
+    public void handleBlockRequest(Player player, byte[] message) {
+        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.wrappedBuffer(message));
+        try {
+            BlockHitResult hitResult = buf.readBlockHitResult();
+
+            ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
+            var world = serverPlayer.level();
+            var pos = hitResult.getBlockPos();
+
+            //noinspection deprecation
+            if (!world.hasChunkAt(pos)) {
+                return;
+            }
+
+            var blockEntity = world.getBlockEntity(pos);
+            if (blockEntity == null) {
+                return;
+            }
+
+            var state = world.getBlockState(pos);
+            var registrar = Registrar.get();
+            var raw = DataWriter.SERVER.reset();
+            IServerAccessor<BlockEntity> accessor = ServerAccessor.INSTANCE.set(world, serverPlayer, hitResult, blockEntity);
+
+            for (var provider : registrar.blockData.get(blockEntity)) {
+                DataWriter.SERVER.tryAppend(serverPlayer, provider.instance(), accessor, PluginConfig.SERVER, IDataProvider::appendData);
+            }
+
+            for (var provider : registrar.blockData.get(state.getBlock())) {
+                DataWriter.SERVER.tryAppend(serverPlayer, provider.instance(), accessor, PluginConfig.SERVER, IDataProvider::appendData);
+            }
+
+            raw.putInt("x", pos.getX());
+            raw.putInt("y", pos.getY());
+            raw.putInt("z", pos.getZ());
+            //noinspection ConstantConditions
+            raw.putString("id", BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(blockEntity.getType()).toString());
+            raw.putLong("WailaTime", System.currentTimeMillis());
+
+            var sender = new PaperPacketSender(plugin, player, serverPlayer);
+            DataWriter.SERVER.send(sender, serverPlayer);
+            DataReader.SERVER.reset(null);
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to handle block data request from " + player.getName(), e);
+        } finally {
+            buf.release();
+        }
+    }
+
+    /**
+     * Handles an entity data request from the client.
+     * <p>
+     * Deserializes the entity id (VarInt) and hit position (3 doubles) from the raw bytes,
+     * looks up the entity, runs all registered data providers, and sends the response
+     * via the full DataWriter pipeline.
+     */
+    public void handleEntityRequest(Player player, byte[] message) {
+        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.wrappedBuffer(message));
+        try {
+            int entityId = buf.readVarInt();
+            double hitX = buf.readDouble();
+            double hitY = buf.readDouble();
+            double hitZ = buf.readDouble();
+
+            ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
+            var world = serverPlayer.level();
+
+            Entity entity = world.getEntity(entityId);
+            if (entity == null) {
+                return;
+            }
+
+            var registrar = Registrar.get();
+            var raw = DataWriter.SERVER.reset();
+            IServerAccessor<Entity> accessor = ServerAccessor.INSTANCE.set(world, serverPlayer, new EntityHitResult(entity, new Vec3(hitX, hitY, hitZ)), entity);
+
+            for (var provider : registrar.entityData.get(entity)) {
+                DataWriter.SERVER.tryAppend(serverPlayer, provider.instance(), accessor, PluginConfig.SERVER, IDataProvider::appendData);
+            }
+
+            raw.putInt("WailaEntityID", entity.getId());
+            raw.putLong("WailaTime", System.currentTimeMillis());
+
+            var sender = new PaperPacketSender(plugin, player, serverPlayer);
+            DataWriter.SERVER.send(sender, serverPlayer);
+            DataReader.SERVER.reset(null);
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to handle entity data request from " + player.getName(), e);
+        } finally {
+            buf.release();
+        }
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperPacketSender.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperPacketSender.java
@@ -1,0 +1,83 @@
+package mcp.mobius.waila.paper;
+
+import java.util.logging.Logger;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import lol.bai.badpackets.api.PacketSender;
+import mcp.mobius.waila.access.DataType;
+import mcp.mobius.waila.network.play.s2c.RawDataResponsePlayS2CPacket;
+import mcp.mobius.waila.network.play.s2c.TypedDataResponsePlayS2CPacket;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Adapts BadPackets' {@link PacketSender} to Bukkit's plugin messaging API.
+ * <p>
+ * Note: {@code PacketSender} is {@code @ApiStatus.NonExtendable}, meaning the library author
+ * may add new abstract methods in future versions. This implementation only needs
+ * {@link #canSend(Identifier)} and {@link #send(CustomPacketPayload, ChannelFutureListener)},
+ * which are the two methods called by {@code DataWriter.SERVER.send()}. If BadPackets adds
+ * new abstract methods, this class will need to be updated.
+ */
+public class PaperPacketSender implements PacketSender {
+
+    private final Plugin plugin;
+    private final Player bukkitPlayer;
+    private final ServerPlayer serverPlayer;
+    private final Logger logger;
+
+    public PaperPacketSender(Plugin plugin, Player bukkitPlayer, ServerPlayer serverPlayer) {
+        this.plugin = plugin;
+        this.bukkitPlayer = bukkitPlayer;
+        this.serverPlayer = serverPlayer;
+        this.logger = plugin.getLogger();
+    }
+
+    @Override
+    public boolean canSend(Identifier id) {
+        return id.equals(RawDataResponsePlayS2CPacket.TYPE.id())
+            || id.equals(TypedDataResponsePlayS2CPacket.ID);
+    }
+
+    @Override
+    public void send(CustomPacketPayload payload, @Nullable ChannelFutureListener callback) {
+        if (callback != null) {
+            throw new UnsupportedOperationException("PaperPacketSender does not support send callbacks");
+        }
+
+        if (payload instanceof RawDataResponsePlayS2CPacket.Payload rawPayload) {
+            var buf = new FriendlyByteBuf(Unpooled.buffer());
+            try {
+                buf.writeNbt(rawPayload.data());
+                sendBytes(PaperWaila.CHANNEL_DATA_RAW, buf);
+            } finally {
+                buf.release();
+            }
+        } else if (payload instanceof TypedDataResponsePlayS2CPacket.Payload typedPayload) {
+            var registryAccess = serverPlayer.level().registryAccess();
+            var buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), registryAccess);
+            try {
+                DataType.CODEC.encode(buf, typedPayload.data());
+                sendBytes(PaperWaila.CHANNEL_DATA_TYPED, buf);
+            } finally {
+                buf.release();
+            }
+        } else {
+            logger.warning("[WTHIT] Unknown payload type: " + payload.getClass().getName());
+        }
+    }
+
+    private void sendBytes(String channel, FriendlyByteBuf buf) {
+        var bytes = new byte[buf.readableBytes()];
+        buf.readBytes(bytes);
+        bukkitPlayer.sendPluginMessage(plugin, channel, bytes);
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperPluginLoader.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperPluginLoader.java
@@ -1,0 +1,24 @@
+package mcp.mobius.waila.paper;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import mcp.mobius.waila.plugin.PluginLoader;
+
+public class PaperPluginLoader extends PluginLoader {
+
+    @Override
+    protected void gatherPlugins() {
+        for (var file : PLUGIN_JSON_FILES) {
+            var resource = getClass().getClassLoader().getResourceAsStream(file);
+            if (resource != null) {
+                try (resource) {
+                    readPluginsJson("wthit", resource, InputStreamReader::new);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to close plugin resource: " + file, e);
+                }
+            }
+        }
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperReflectionProviders.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperReflectionProviders.java
@@ -1,0 +1,206 @@
+package mcp.mobius.waila.paper;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import mcp.mobius.waila.api.IDataProvider;
+import mcp.mobius.waila.api.IDataWriter;
+import mcp.mobius.waila.api.IPluginConfig;
+import mcp.mobius.waila.api.IServerAccessor;
+import mcp.mobius.waila.api.data.ItemData;
+import mcp.mobius.waila.api.data.ProgressData;
+import mcp.mobius.waila.plugin.vanilla.config.Options;
+import mcp.mobius.waila.plugin.vanilla.provider.data.BeaconDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.BeehiveDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.LecternDataProvider;
+import mcp.mobius.waila.util.Log;
+import net.minecraft.core.Holder;
+import net.minecraft.world.LockCode;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.level.block.AbstractFurnaceBlock;
+import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.world.level.block.entity.BaseContainerBlockEntity;
+import net.minecraft.world.level.block.entity.BeaconBlockEntity;
+import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
+import net.minecraft.world.level.block.entity.LecternBlockEntity;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reflection-based replacements for the mixin data providers.
+ * <p>
+ * Paper uses Mojang-mapped NMS so we can access private fields via reflection
+ * instead of Fabric's mixin accessors.
+ */
+final class PaperReflectionProviders {
+
+    private static final Log LOG = Log.create();
+
+    private PaperReflectionProviders() {
+    }
+
+    private static @Nullable Field field(Class<?> clazz, String name) {
+        try {
+            var f = clazz.getDeclaredField(name);
+            f.setAccessible(true);
+            return f;
+        } catch (Exception e) {
+            LOG.warn("Failed to resolve field " + clazz.getSimpleName() + "." + name + ", provider will be a no-op: " + e.getMessage());
+            return null;
+        }
+    }
+
+    enum Furnace implements IDataProvider<AbstractFurnaceBlockEntity> {
+        INSTANCE;
+
+        private static final @Nullable Field COOKING_TIMER = field(AbstractFurnaceBlockEntity.class, "cookingTimer");
+        private static final @Nullable Field COOKING_TOTAL_TIME = field(AbstractFurnaceBlockEntity.class, "cookingTotalTime");
+
+        @Override
+        public void appendData(IDataWriter data, IServerAccessor<AbstractFurnaceBlockEntity> accessor, IPluginConfig config) {
+            if (COOKING_TIMER == null || COOKING_TOTAL_TIME == null) return;
+
+            data.add(ProgressData.TYPE, res -> {
+                var furnace = accessor.getTarget();
+                if (furnace.getBlockState().getValue(AbstractFurnaceBlock.LIT)) {
+                    try {
+                        int timer = COOKING_TIMER.getInt(furnace);
+                        int total = COOKING_TOTAL_TIME.getInt(furnace);
+                        res.add(ProgressData
+                            .tick(timer, total)
+                            .itemGetter(furnace::getItem)
+                            .input(0, 1)
+                            .output(2));
+                    } catch (IllegalAccessException e) {
+                        // no-op
+                    }
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    enum Beacon implements IDataProvider<BeaconBlockEntity> {
+        INSTANCE;
+
+        private static final @Nullable Field PRIMARY_POWER = field(BeaconBlockEntity.class, "primaryPower");
+        private static final @Nullable Field SECONDARY_POWER = field(BeaconBlockEntity.class, "secondaryPower");
+        private static final @Nullable Field LEVELS = field(BeaconBlockEntity.class, "levels");
+
+        @Override
+        public void appendData(IDataWriter data, IServerAccessor<BeaconBlockEntity> accessor, IPluginConfig config) {
+            if (PRIMARY_POWER == null || SECONDARY_POWER == null || LEVELS == null) return;
+
+            if (config.getBoolean(Options.EFFECT_BEACON)) data.add(BeaconDataProvider.DATA, res -> {
+                try {
+                    var beacon = accessor.getTarget();
+                    var primary = (Holder<MobEffect>) PRIMARY_POWER.get(beacon);
+                    var secondary = (Holder<MobEffect>) SECONDARY_POWER.get(beacon);
+                    int levels = LEVELS.getInt(beacon);
+                    res.add(new BeaconDataProvider.Data(primary, levels >= 4 ? secondary : null));
+                } catch (IllegalAccessException e) {
+                    // no-op
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    enum Beehive implements IDataProvider<BeehiveBlockEntity> {
+        INSTANCE;
+
+        private static final @Nullable Field STORED = field(BeehiveBlockEntity.class, "stored");
+        private static final @Nullable Field BEE_DATA_OCCUPANT;
+
+        static {
+            Field occupantField = null;
+            try {
+                Class<?> beeDataClass = null;
+                for (var inner : BeehiveBlockEntity.class.getDeclaredClasses()) {
+                    if (inner.getSimpleName().equals("BeeData")) {
+                        beeDataClass = inner;
+                        break;
+                    }
+                }
+                if (beeDataClass != null) {
+                    occupantField = beeDataClass.getDeclaredField("occupant");
+                    occupantField.setAccessible(true);
+                } else {
+                    LOG.warn("Failed to find BeehiveBlockEntity.BeeData inner class, beehive provider will be a no-op");
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to resolve BeehiveBlockEntity.BeeData.occupant, beehive provider will be a no-op: {}", e.getMessage());
+            }
+            BEE_DATA_OCCUPANT = occupantField;
+        }
+
+        @Override
+        public void appendData(IDataWriter data, IServerAccessor<BeehiveBlockEntity> accessor, IPluginConfig config) {
+            if (STORED == null || BEE_DATA_OCCUPANT == null) return;
+
+            if (config.getBoolean(Options.BEE_HIVE_OCCUPANTS)) {
+                try {
+                    var stored = (List<?>) STORED.get(accessor.getTarget());
+                    if (stored != null && !stored.isEmpty()) {
+                        var occupants = new ArrayList<BeehiveDataProvider.OccupantsData.Occupant>(stored.size());
+
+                        for (var beeData : stored) {
+                            var occupant = (BeehiveBlockEntity.Occupant) BEE_DATA_OCCUPANT.get(beeData);
+                            var entityType = occupant.entityData().type();
+                            var beeNbt = occupant.entityData().copyTagWithoutId();
+                            var customName = beeNbt.getString("CustomName").orElse(null);
+                            occupants.add(new BeehiveDataProvider.OccupantsData.Occupant(entityType, customName));
+                        }
+
+                        data.addImmediate(new BeehiveDataProvider.OccupantsData(occupants));
+                    }
+                } catch (IllegalAccessException e) {
+                    // no-op
+                }
+            }
+        }
+    }
+
+    enum Lectern implements IDataProvider<LecternBlockEntity> {
+        INSTANCE;
+
+        private static final @Nullable Field PAGE_COUNT = field(LecternBlockEntity.class, "pageCount");
+
+        @Override
+        public void appendData(IDataWriter data, IServerAccessor<LecternBlockEntity> accessor, IPluginConfig config) {
+            if (PAGE_COUNT == null) return;
+            if (!config.getBoolean(Options.BOOK_LECTERN)) return;
+
+            var lectern = accessor.getTarget();
+            if (!lectern.hasBook()) return;
+
+            try {
+                int pageCount = PAGE_COUNT.getInt(lectern);
+                data.addImmediate(new LecternDataProvider.Data(lectern.getBook(), lectern.getPage() + 1, pageCount));
+            } catch (IllegalAccessException e) {
+                // no-op
+            }
+        }
+    }
+
+    enum BaseContainer implements IDataProvider<BaseContainerBlockEntity> {
+        INSTANCE;
+
+        private static final @Nullable Field LOCK_KEY = field(BaseContainerBlockEntity.class, "lockKey");
+
+        @Override
+        public void appendData(IDataWriter data, IServerAccessor<BaseContainerBlockEntity> accessor, IPluginConfig config) {
+            if (LOCK_KEY == null) return;
+
+            try {
+                var lockKey = (LockCode) LOCK_KEY.get(accessor.getTarget());
+                if (!lockKey.unlocksWith(accessor.getPlayer().getMainHandItem())) {
+                    data.blockAll(ItemData.TYPE);
+                }
+            } catch (IllegalAccessException e) {
+                // no-op
+            }
+        }
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperVanillaCommonPlugin.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperVanillaCommonPlugin.java
@@ -1,0 +1,170 @@
+package mcp.mobius.waila.paper;
+
+import mcp.mobius.waila.api.ICommonRegistrar;
+import mcp.mobius.waila.api.IWailaCommonPlugin;
+import mcp.mobius.waila.api.IntFormat;
+import mcp.mobius.waila.plugin.vanilla.config.EnchantmentDisplayMode;
+import mcp.mobius.waila.plugin.vanilla.config.NoteDisplayMode;
+import mcp.mobius.waila.plugin.vanilla.config.Options;
+import mcp.mobius.waila.plugin.vanilla.provider.data.BeaconDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.BeeDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.BeehiveDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.ContainerEntityDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.EnderChestDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.EntityAttributesDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.HopperContainerDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.JukeboxDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.LecternDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.MobEffectDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.MobTimerDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.PetOwnerDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.RandomizableContainerDataProvider;
+import mcp.mobius.waila.plugin.vanilla.provider.data.SelectableSlotContainerDataProvider;
+import net.minecraft.world.Container;
+import net.minecraft.world.RandomizableContainer;
+import net.minecraft.world.entity.AgeableMob;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.OwnableEntity;
+import net.minecraft.world.entity.animal.bee.Bee;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.world.level.block.entity.BaseContainerBlockEntity;
+import net.minecraft.world.level.block.entity.BeaconBlockEntity;
+import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.ChiseledBookShelfBlockEntity;
+import net.minecraft.world.level.block.entity.EnderChestBlockEntity;
+import net.minecraft.world.level.block.entity.JukeboxBlockEntity;
+import net.minecraft.world.level.block.entity.LecternBlockEntity;
+import net.minecraft.world.level.block.entity.ShelfBlockEntity;
+
+/**
+ * Paper-specific replacement for {@code VanillaCommonPlugin}.
+ * <p>
+ * On Fabric/Forge, several data providers use mixin accessors to read private NMS fields.
+ * Paper has no mixin system, so this plugin uses reflection-based replacements in
+ * {@link PaperReflectionProviders} for furnace progress, beacon effects, beehive occupants,
+ * lectern pages, and container lock checking.
+ */
+public class PaperVanillaCommonPlugin implements IWailaCommonPlugin {
+
+    @Override
+    public void register(ICommonRegistrar registrar) {
+        registrar.localConfig(Options.BLOCK_POSITION, false);
+        registrar.localConfig(Options.BLOCK_STATE, false);
+
+        registrar.featureConfig(Options.ENTITY_ITEM_ENTITY, true);
+
+        registrar.localConfig(Options.ENTITY_POSITION, false);
+        registrar.featureConfig(Options.ENTITY_HEALTH, true);
+        registrar.featureConfig(Options.ENTITY_ABSORPTION, false);
+        registrar.featureConfig(Options.ENTITY_ARMOR, true);
+        registrar.localConfig(Options.ENTITY_COMPACT, false);
+        registrar.localConfig(Options.ENTITY_ICON_PER_LINE, 25);
+        registrar.localConfig(Options.ENTITY_LONG_HEALTH_MAX, 100);
+        registrar.localConfig(Options.ENTITY_LONG_ARMOR_MAX, 100);
+        registrar.entityData(EntityAttributesDataProvider.INSTANCE, Entity.class);
+
+        registrar.featureConfig(Options.PET_OWNER, false);
+        registrar.localConfig(Options.PET_HIDE_UNKNOWN_OWNER, false);
+        registrar.entityData(PetOwnerDataProvider.INSTANCE, OwnableEntity.class);
+
+        registrar.featureConfig(Options.HORSE_JUMP_HEIGHT, true);
+        registrar.featureConfig(Options.HORSE_SPEED, true);
+
+        registrar.featureConfig(Options.PANDA_GENES, true);
+
+        registrar.featureConfig(Options.BEE_HIVE_POS, false);
+        registrar.featureConfig(Options.BEE_HIVE_HONEY_LEVEL, true);
+        registrar.featureConfig(Options.BEE_HIVE_OCCUPANTS, false);
+        registrar.dataType(BeehiveDataProvider.OCCUPANTS, BeehiveDataProvider.OCCUPANTS_CODEC);
+        registrar.dataType(BeeDataProvider.HIVE_POS, BeeDataProvider.HIVE_POS_CODEC);
+        registrar.blockData(PaperReflectionProviders.Beehive.INSTANCE, BeehiveBlockEntity.class);
+        registrar.entityData(BeeDataProvider.INSTANCE, Bee.class);
+
+        registrar.featureConfig(Options.EFFECT_BEACON, false);
+        registrar.dataType(BeaconDataProvider.DATA, BeaconDataProvider.DATA_CODEC);
+        registrar.blockData(PaperReflectionProviders.Beacon.INSTANCE, BeaconBlockEntity.class);
+
+        registrar.featureConfig(Options.EFFECT_MOB, false);
+        registrar.syncedConfig(Options.EFFECT_HIDDEN_MOB, false, false);
+        registrar.dataType(MobEffectDataProvider.DATA, MobEffectDataProvider.DATA_CODEC);
+        registrar.entityData(MobEffectDataProvider.INSTANCE, LivingEntity.class);
+
+        registrar.featureConfig(Options.JUKEBOX_RECORD, false);
+        registrar.dataType(JukeboxDataProvider.DATA, JukeboxDataProvider.DATA_CODEC);
+        registrar.blockData(JukeboxDataProvider.INSTANCE, JukeboxBlockEntity.class);
+
+        registrar.featureConfig(Options.TIMER_GROW, false);
+        registrar.featureConfig(Options.TIMER_BREED, false);
+        registrar.entityData(MobTimerDataProvider.INSTANCE, AgeableMob.class);
+
+        registrar.featureConfig(Options.OVERRIDE_INVISIBLE_ENTITY, true);
+        registrar.featureConfig(Options.OVERRIDE_TRAPPED_CHEST, true);
+        registrar.featureConfig(Options.OVERRIDE_POWDER_SNOW, true);
+        registrar.featureConfig(Options.OVERRIDE_INFESTED, true);
+        registrar.localConfig(Options.OVERRIDE_VEHICLE, true);
+
+        registrar.featureConfig(Options.BREAKING_PROGRESS, true);
+        registrar.localConfig(Options.BREAKING_PROGRESS_COLOR, 0xAAFFFFFF, IntFormat.ARGB_HEX);
+        registrar.localConfig(Options.BREAKING_PROGRESS_BOTTOM_ONLY, false);
+
+        registrar.featureConfig(Options.SPAWNER_TYPE, true);
+
+        registrar.featureConfig(Options.PLANT_CROP_PROGRESS, true);
+        registrar.featureConfig(Options.PLANT_CROP_GROWABLE, true);
+        registrar.featureConfig(Options.PLANT_TREE_GROWABLE, true);
+
+        registrar.featureConfig(Options.REDSTONE_LEVER, true);
+        registrar.featureConfig(Options.REDSTONE_REPEATER, true);
+        registrar.featureConfig(Options.REDSTONE_COMPARATOR, true);
+        registrar.featureConfig(Options.REDSTONE_LEVEL, true);
+
+        registrar.featureConfig(Options.LEVEL_COMPOSTER, true);
+
+        registrar.featureConfig(Options.NOTE_BLOCK_TYPE, true);
+        registrar.localConfig(Options.NOTE_BLOCK_NOTE, NoteDisplayMode.SHARP);
+        registrar.localConfig(Options.NOTE_BLOCK_INT_VALUE, false);
+
+        registrar.dataType(SelectableSlotContainerDataProvider.DATA, SelectableSlotContainerDataProvider.DATA_CODEC);
+
+        registrar.featureConfig(Options.SHELF_ITEMS, false);
+        registrar.blockData(SelectableSlotContainerDataProvider.SHELF, ShelfBlockEntity.class);
+
+        registrar.featureConfig(Options.BOOK_BOOKSHELF, false);
+        registrar.featureConfig(Options.BOOK_LECTERN, false);
+        registrar.localConfig(Options.BOOK_ENCHANTMENT_DISPLAY_MODE, EnchantmentDisplayMode.CYCLE);
+        registrar.localConfig(Options.BOOK_ENCHANTMENT_CYCLE_TIMING, 500);
+        registrar.localConfig(Options.BOOK_DETAILS, true);
+        registrar.blockData(SelectableSlotContainerDataProvider.BOOKSHELF, ChiseledBookShelfBlockEntity.class);
+        registrar.dataType(LecternDataProvider.DATA, LecternDataProvider.DATA_CODEC);
+        registrar.blockData(PaperReflectionProviders.Lectern.INSTANCE, LecternBlockEntity.class);
+
+        registrar.blockData(PaperReflectionProviders.Furnace.INSTANCE, AbstractFurnaceBlockEntity.class);
+        registrar.blockData(EnderChestDataProvider.INSTANCE, EnderChestBlockEntity.class);
+
+        registrar.blockData(RandomizableContainerDataProvider.INSTANCE, RandomizableContainer.class, 1100);
+        registrar.blockData(PaperReflectionProviders.BaseContainer.INSTANCE, BaseContainerBlockEntity.class, 1200);
+        registrar.blockData(HopperContainerDataProvider.INSTANCE, BlockEntity.class, 1300);
+
+        registrar.entityData(ContainerEntityDataProvider.INSTANCE, Container.class, 1100);
+
+        registrar.blacklist(1100,
+            Blocks.BARRIER,
+            Blocks.STRUCTURE_VOID,
+            Blocks.LIGHT);
+
+        registrar.blacklist(1100,
+            EntityType.AREA_EFFECT_CLOUD,
+            EntityType.EXPERIENCE_ORB,
+            EntityType.FIREBALL,
+            EntityType.FIREWORK_ROCKET,
+            EntityType.INTERACTION,
+            EntityType.SNOWBALL);
+
+        Options.ALIASES.forEach(registrar::configAlias);
+    }
+
+}

--- a/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperWaila.java
+++ b/platform/paper/src/main/java/mcp/mobius/waila/paper/PaperWaila.java
@@ -1,0 +1,239 @@
+package mcp.mobius.waila.paper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import mcp.mobius.waila.Waila;
+import mcp.mobius.waila.config.ConfigEntry;
+import mcp.mobius.waila.config.PluginConfig;
+import mcp.mobius.waila.plugin.PluginInfo;
+import mcp.mobius.waila.plugin.PluginLoader;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
+import net.minecraft.network.protocol.common.custom.DiscardedPayload;
+import net.minecraft.resources.Identifier;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerRegisterChannelEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+import static mcp.mobius.waila.mcless.network.NetworkConstants.CONFIG_BOOL;
+import static mcp.mobius.waila.mcless.network.NetworkConstants.CONFIG_DOUBLE;
+import static mcp.mobius.waila.mcless.network.NetworkConstants.CONFIG_INT;
+import static mcp.mobius.waila.mcless.network.NetworkConstants.CONFIG_STRING;
+import static mcp.mobius.waila.mcless.network.NetworkConstants.NETWORK_VERSION;
+
+public class PaperWaila extends JavaPlugin implements Listener, PluginMessageListener {
+
+    static final String CHANNEL_VERSION = "waila:version";
+    static final String CHANNEL_CONFIG = "waila:config";
+    static final String CHANNEL_BLACKLIST = "waila:blacklist";
+
+    static final String CHANNEL_BLOCK = "waila:block";
+    static final String CHANNEL_ENTITY = "waila:entity";
+
+    static final String CHANNEL_DATA_TYPED = "waila:data_typed";
+    // Matches RawDataResponsePlayS2CPacket.TYPE.id() → Waila.id("data")
+    static final String CHANNEL_DATA_RAW = "waila:data";
+
+    // BadPackets channel sync protocol - required for Fabric clients using BadPackets
+    static final String CHANNEL_BP_SYNC = "badpackets:channel_sync";
+    static final byte BP_SYNC_INITIAL = 0x01;
+
+    private PaperDataHandler dataHandler;
+
+    @Override
+    public void onEnable() {
+        // ServiceLoader.load() uses the thread context classloader, which on Paper's plugin system
+        // is not the plugin classloader. Swap it for the entire onEnable so that ServiceLoader can
+        // find our services (ICommonService, PluginLoader, etc.) in the plugin JAR.
+        var previousClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+        try {
+            dataHandler = new PaperDataHandler(this);
+
+            Bukkit.getPluginManager().registerEvents(this, this);
+
+            // BadPackets channel sync - register incoming to receive the client's response.
+            // Outgoing sync is sent via NMS (bypasses Bukkit's channel check).
+            Bukkit.getMessenger().registerIncomingPluginChannel(this, CHANNEL_BP_SYNC, this);
+
+            // Outgoing channels
+            Bukkit.getMessenger().registerOutgoingPluginChannel(this, CHANNEL_VERSION);
+            Bukkit.getMessenger().registerOutgoingPluginChannel(this, CHANNEL_CONFIG);
+            Bukkit.getMessenger().registerOutgoingPluginChannel(this, CHANNEL_BLACKLIST);
+            Bukkit.getMessenger().registerOutgoingPluginChannel(this, CHANNEL_DATA_TYPED);
+            Bukkit.getMessenger().registerOutgoingPluginChannel(this, CHANNEL_DATA_RAW);
+
+            // Incoming channels
+            Bukkit.getMessenger().registerIncomingPluginChannel(this, CHANNEL_BLOCK, this);
+            Bukkit.getMessenger().registerIncomingPluginChannel(this, CHANNEL_ENTITY, this);
+
+            // Initialize the WTHIT plugin system - loads data providers, populates PluginConfig
+            // and Waila.BLACKLIST_CONFIG with registered values.
+            PluginLoader.INSTANCE.loadPlugins();
+
+            var plugins = PluginInfo.getAll();
+            getLogger().info("[WTHIT] Loaded " + plugins.size() + " plugins:");
+            for (var info : plugins) {
+                getLogger().info("[WTHIT]   " + info.getPluginId() + " (enabled=" + info.isEnabled() + ")");
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        // Send BadPackets channel sync to the Fabric client so it registers waila:* channels.
+        // BadPackets on the client only sends minecraft:register for its managed channels AFTER
+        // receiving a badpackets:channel_sync INITIAL packet from the server.
+        // Use a 1-tick delay to ensure the player's network handler is fully ready.
+        Bukkit.getScheduler().runTaskLater(this, () -> {
+            if (event.getPlayer().isOnline()) {
+                sendBadPacketsChannelSync(event.getPlayer());
+            }
+        }, 1L);
+    }
+
+    @EventHandler
+    @SuppressWarnings("UnstableApiUsage")
+    public void onPlayerRegisterChannelEvent(PlayerRegisterChannelEvent event) {
+        Player player = event.getPlayer();
+        if (event.getChannel().equals(CHANNEL_VERSION)) {
+            ByteArrayDataOutput out = ByteStreams.newDataOutput();
+            writeVarInt(out, NETWORK_VERSION);
+            player.sendPluginMessage(this, CHANNEL_VERSION, out.toByteArray());
+        }
+
+        if (event.getChannel().equals(CHANNEL_BLACKLIST)) {
+            // Use WTHIT's own blacklist config (populated during loadPlugins) instead of a
+            // custom config file. Wire format matches BlacklistSyncCommonS2CPacket.CODEC:
+            // three flat string sets (blocks, blockEntityTypes, entityTypes).
+            var blacklist = Waila.BLACKLIST_CONFIG.get();
+            ByteArrayDataOutput out = ByteStreams.newDataOutput();
+            writeStringSet(out, blacklist.blocks);
+            writeStringSet(out, blacklist.blockEntityTypes);
+            writeStringSet(out, blacklist.entityTypes);
+            player.sendPluginMessage(this, CHANNEL_BLACKLIST, out.toByteArray());
+        }
+
+        if (event.getChannel().equals(CHANNEL_CONFIG)) {
+            // Use PluginConfig.getSyncableConfigs() to build the config packet, matching
+            // exactly what the Fabric server does in ConfigSyncCommonS2CPacket.Payload().
+            // This ensures the client receives proper server values for all synced configs
+            // (e.g. featureConfig entries like wailax:item.enabled_block default to true).
+            var syncableConfigs = PluginConfig.getSyncableConfigs().stream()
+                .filter(it -> it.getOrigin().isEnabled())
+                .collect(Collectors.toMap(ConfigEntry::getId, ConfigEntry::getLocalValue));
+
+            var groups = syncableConfigs.keySet().stream()
+                .collect(Collectors.groupingBy(Identifier::getNamespace));
+
+            ByteArrayDataOutput out = ByteStreams.newDataOutput();
+            writeVarInt(out, groups.size());
+            groups.forEach((namespace, entries) -> {
+                writeUtf(out, namespace);
+                writeVarInt(out, entries.size());
+                entries.forEach(e -> {
+                    writeUtf(out, e.getPath());
+                    var v = syncableConfigs.get(e);
+                    if (v instanceof Boolean z) {
+                        out.writeByte(CONFIG_BOOL);
+                        out.writeBoolean(z);
+                    } else if (v instanceof Integer i) {
+                        out.writeByte(CONFIG_INT);
+                        writeVarInt(out, i);
+                    } else if (v instanceof Double d) {
+                        out.writeByte(CONFIG_DOUBLE);
+                        out.writeDouble(d);
+                    } else if (v instanceof String str) {
+                        out.writeByte(CONFIG_STRING);
+                        writeUtf(out, str);
+                    } else if (v instanceof Enum<?> en) {
+                        out.writeByte(CONFIG_STRING);
+                        writeUtf(out, en.name());
+                    }
+                });
+            });
+            player.sendPluginMessage(this, CHANNEL_CONFIG, out.toByteArray());
+        }
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte @NotNull [] message) {
+        switch (channel) {
+            case CHANNEL_BLOCK -> dataHandler.handleBlockRequest(player, message);
+            case CHANNEL_ENTITY -> dataHandler.handleEntityRequest(player, message);
+        }
+    }
+
+    /**
+     * Sends a BadPackets channel_sync INITIAL packet to the client via NMS, advertising all waila:* channels.
+     * This is required because BadPackets on the Fabric client only registers channels via
+     * minecraft:register AFTER it receives this sync from the server.
+     * <p>
+     * Must bypass Bukkit's {@code sendPluginMessage} because Bukkit silently drops messages
+     * to channels the client hasn't registered yet — but the whole point of this packet is to
+     * trigger that registration.
+     * <p>
+     * Wire format: [byte: 0x01] [varint: namespace_count] [for each: utf namespace, varint path_count, [utf path...]]
+     */
+    private void sendBadPacketsChannelSync(Player player) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeByte(BP_SYNC_INITIAL);
+
+        // All channels are in the "waila" namespace
+        writeVarInt(out, 1); // 1 namespace group
+        writeUtf(out, "waila");
+        writeVarInt(out, 7); // 7 channel paths
+        writeUtf(out, "version");
+        writeUtf(out, "config");
+        writeUtf(out, "blacklist");
+        writeUtf(out, "block");
+        writeUtf(out, "entity");
+        writeUtf(out, "data_typed");
+        writeUtf(out, "data");
+
+        // Send directly via NMS to bypass Bukkit's channel registration check
+        var nmsPlayer = ((CraftPlayer) player).getHandle();
+        var packet = new ClientboundCustomPayloadPacket(
+            new DiscardedPayload(Identifier.parse(CHANNEL_BP_SYNC), out.toByteArray())
+        );
+        nmsPlayer.connection.send(packet);
+    }
+
+    static void writeVarInt(ByteArrayDataOutput out, int i) {
+        while ((i & -128) != 0) {
+            out.writeByte(i & 127 | 128);
+            i >>>= 7;
+        }
+        out.writeByte(i);
+    }
+
+    static void writeUtf(ByteArrayDataOutput out, String str) {
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > 32767) {
+            throw new RuntimeException("String too big (was " + bytes.length + " bytes encoded, max " + 32767 + ")");
+        } else {
+            writeVarInt(out, bytes.length);
+            out.write(bytes);
+        }
+    }
+
+    private static void writeStringSet(ByteArrayDataOutput out, Set<String> set) {
+        writeVarInt(out, set.size());
+        for (var s : set) {
+            writeUtf(out, s);
+        }
+    }
+
+}

--- a/platform/paper/src/main/resources/META-INF/services/mcp.mobius.waila.api.__internal__.IApiService
+++ b/platform/paper/src/main/resources/META-INF/services/mcp.mobius.waila.api.__internal__.IApiService
@@ -1,0 +1,1 @@
+mcp.mobius.waila.paper.PaperApiService

--- a/platform/paper/src/main/resources/META-INF/services/mcp.mobius.waila.plugin.PluginLoader
+++ b/platform/paper/src/main/resources/META-INF/services/mcp.mobius.waila.plugin.PluginLoader
@@ -1,0 +1,1 @@
+mcp.mobius.waila.paper.PaperPluginLoader

--- a/platform/paper/src/main/resources/META-INF/services/mcp.mobius.waila.service.ICommonService
+++ b/platform/paper/src/main/resources/META-INF/services/mcp.mobius.waila.service.ICommonService
@@ -1,0 +1,1 @@
+mcp.mobius.waila.paper.PaperCommonService

--- a/platform/paper/src/main/resources/paper-plugin.yml
+++ b/platform/paper/src/main/resources/paper-plugin.yml
@@ -1,0 +1,10 @@
+name: wthit
+version: ${version}
+main: mcp.mobius.waila.paper.PaperWaila
+api-version: '1.21'
+description: Server companion plugin for WTHIT
+authors:
+  - deirn
+  - TehNut
+  - ProfMobius
+website: https://github.com/badasintended/wthit

--- a/platform/paper/src/main/resources/waila_plugins.json
+++ b/platform/paper/src/main/resources/waila_plugins.json
@@ -1,0 +1,37 @@
+{
+  "waila:core"   : {
+    "entrypoints": {
+      "common": "mcp.mobius.waila.plugin.core.CoreCommonPlugin",
+      "client": "mcp.mobius.waila.plugin.core.CoreClientPlugin"
+    },
+    "side"       : "*",
+    "required"   : []
+  },
+
+  "waila:vanilla": {
+    "entrypoints": {
+      "common": "mcp.mobius.waila.paper.PaperVanillaCommonPlugin",
+      "client": "mcp.mobius.waila.plugin.vanilla.VanillaClientPlugin"
+    },
+    "side"       : "*",
+    "required"   : ["minecraft"]
+  },
+
+  "waila:harvest": {
+    "entrypoints": {
+      "common": "mcp.mobius.waila.plugin.harvest.HarvestCommonPlugin",
+      "client": "mcp.mobius.waila.plugin.harvest.HarvestClientPlugin"
+    },
+    "side"       : "*",
+    "required"   : []
+  },
+
+  "waila:extra"  : {
+    "entrypoints": {
+      "common": "mcp.mobius.waila.plugin.extra.ExtraPlugin",
+      "client": "mcp.mobius.waila.plugin.extra.ExtraPlugin"
+    },
+    "side"       : "*",
+    "required"   : []
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
         maven("https://maven.minecraftforge.net/")
         maven("https://maven.quiltmc.org/repository/release")
         maven("https://repo.spongepowered.org/repository/maven-public")
+        maven("https://repo.papermc.io/repository/maven-public/")
     }
 
     resolutionStrategy.eachPlugin {
@@ -34,4 +35,5 @@ platform("fabric")
 platform("forge")
 platform("neo")
 platform("textile")
+platform("paper")
 //platform("quilt")

--- a/src/main/java/mcp/mobius/waila/network/Packets.java
+++ b/src/main/java/mcp/mobius/waila/network/Packets.java
@@ -57,6 +57,13 @@ public class Packets {
         PACKETS.forEach(Packet::client);
 
         ConfigPackets.registerClientReadyCallback(Packets::sendVersionPacket);
+
+        // Paper servers don't have config stage, handshake happens on play stage
+        PlayPackets.registerClientReadyCallback(context -> {
+            if (context.canSend(VersionCommonPacket.TYPE)) {
+                sendVersionPacket(context);
+            }
+        });
     }
 
     private static boolean sendVersionPacket(PacketSender sender) {

--- a/src/main/java/mcp/mobius/waila/network/common/VersionCommonPacket.java
+++ b/src/main/java/mcp/mobius/waila/network/common/VersionCommonPacket.java
@@ -28,6 +28,7 @@ public class VersionCommonPacket implements Packet {
         ConfigPackets.registerServerChannel(TYPE, CODEC);
         ConfigPackets.registerClientChannel(TYPE, CODEC);
         PlayPackets.registerServerChannel(TYPE, CODEC);
+        PlayPackets.registerClientChannel(TYPE, CODEC);
 
         ConfigPackets.registerServerReceiver(TYPE, (context, payload) -> receive(context.handler()::disconnect, payload));
         PlayPackets.registerServerReceiver(TYPE, (context, payload) -> receive(context.handler()::disconnect, payload));
@@ -38,6 +39,12 @@ public class VersionCommonPacket implements Packet {
         ConfigPackets.registerClientReceiver(TYPE, (context, payload) -> {
             receive(context::disconnect, payload);
             ClientAccessor.INSTANCE.hasServer = true;
+        });
+
+        PlayPackets.registerClientReceiver(TYPE, (context, payload) -> {
+            if (payload.version() == NETWORK_VERSION) {
+                ClientAccessor.INSTANCE.hasServer = true;
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
  - Adds Paper platform support as a new Gradle subproject
  - Responds with the same packets as a modded server would
  - Registers all the same configs and providers as the Fabric/Forge plugin via PaperVanillaCommonPlugin

### Notes
  - Implements 5 reflection-based data providers (PaperReflectionProviders) to replace Fabric's mixin accessors for furnace progress, beacon effects, beehive occupants, lectern pages, and container lock checking
  

## Test plan

  - Build: ./gradlew :paper:jar
  - Deploy to a Paper server with a Fabric client running WTHIT
  - Verify all server side functions work correctly:
    - container contents
    - furnace cooking progress bar
    - beacon effects
    - beehive occupant list
    - lectern page count
    - container lock hiding

If I'm missing any server side functions to test LMK.

Also note: this was created with claude-code