### PR TITLE
Fix NeoForge capability lookup cache

### DIFF
--- a/platform/neo/src/plugin/java/mcp/mobius/waila/plugin/neo/provider/EnergyCapabilityProvider.java
+++ b/platform/neo/src/plugin/java/mcp/mobius/waila/plugin/neo/provider/EnergyCapabilityProvider.java
@@ -26,7 +26,7 @@ public enum EnergyCapabilityProvider implements IDataProvider<BlockEntity> {
             var target = accessor.getTarget();
             var pos = target.getBlockPos();
 
-            if (cache == null || (cache.level() != world && !cache.pos().equals(pos))) {
+            if (cache == null || cache.level() != world || !cache.pos().equals(pos)) {
                 cache = BlockCapabilityCache.create(Capabilities.Energy.BLOCK, world, pos, null);
             }
 

--- a/platform/neo/src/plugin/java/mcp/mobius/waila/plugin/neo/provider/FluidCapabilityProvider.java
+++ b/platform/neo/src/plugin/java/mcp/mobius/waila/plugin/neo/provider/FluidCapabilityProvider.java
@@ -28,7 +28,7 @@ public enum FluidCapabilityProvider implements IDataProvider<BlockEntity> {
             var target = accessor.getTarget();
             var pos = target.getBlockPos();
 
-            if (cache == null || (cache.level() != world && !cache.pos().equals(pos))) {
+            if (cache == null || cache.level() != world || !cache.pos().equals(pos)) {
                 cache = BlockCapabilityCache.create(Capabilities.Fluid.BLOCK, world, pos, null);
             }
 

--- a/platform/neo/src/plugin/java/mcp/mobius/waila/plugin/neo/provider/ItemCapabilityProvider.java
+++ b/platform/neo/src/plugin/java/mcp/mobius/waila/plugin/neo/provider/ItemCapabilityProvider.java
@@ -27,7 +27,7 @@ public enum ItemCapabilityProvider implements IDataProvider<BlockEntity> {
             var target = accessor.getTarget();
             var pos = target.getBlockPos();
 
-            if (cache == null || (cache.level() != world && !cache.pos().equals(pos))) {
+            if (cache == null || cache.level() != world || !cache.pos().equals(pos)) {
                 cache = BlockCapabilityCache.create(Capabilities.Item.BLOCK, world, pos, null);
             }
 


### PR DESCRIPTION
TL;DR: There was a && where a || should have been instead, this now matches Fabric which does the same thing and wasn't broken. This issue is also present on every other version starting from when NeoForge support was added (excluding EOL branches: dev/26.2, dev/26.1, dev/1.21.11, dev/1.21.10, dev/1.21.4, dev/1.21.1, dev/1.20.4)

Long version:
The NeoForge versions of WTHIT, when querying block capabilities for item/energy/fluid handlers, only checked the first block you looked at on world load then applied those values onto everything else. Meaning, if you looked at a grass block first after joining a world, it'd cache the capability providers for the grass block (which, as far as I know, has none).

From then on, you'd just not be able to see any information for any block that implements such providers (e.g a tank would never show a fluid bar), unless they also have their own WTHIT plugin that provides this information independently from the builtin one.

The other scenario is if the first block you look at when joining a world DOES implement such a capability, in which case, that information now shows on every subsequent block you look at (so for example, if you looked at a tank with 1000mB of water in it first, then at a chest, the chest would also show as if it contained 1000mB of water).

The Fabric version did not ever have this issue on any version as it uses || instead of && in the first place correctly.